### PR TITLE
Update jquery.loadscript.js

### DIFF
--- a/jquery.loadscript.js
+++ b/jquery.loadscript.js
@@ -52,7 +52,7 @@
 		// Handle p_params is exist
 		if (arguments.length === 2 && typeof arguments[1] === 'function') {
 			p_callback = arguments[1];
-			p_params = null;
+			p_params = {};
 		}
 
 		var _return = $.Deferred();


### PR DESCRIPTION
p_params should be an empty object.
if it is null, there will be an error "Uncaught TypeError: Cannot read property 'lazyLoad' of null"